### PR TITLE
Add techId existence check in BuildRelatedTechString

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -229,6 +229,9 @@ foreach ((string id, Tech tech) in techs) {
 	sb.Append($"{LocConsts.RParen}§!");
 
 	void BuildRelatedTechString(string techId, int indent) {
+		if (!techs.ContainsKey(techId)) {
+			return;
+		}
 		Tech tech = techs[techId];
 
 		sb.Append("\n$");


### PR DESCRIPTION
Hi! I really like the idea behind this parser, especially because it means the tech tree mod will always be compatible with the mods I'm currently using. When I first tried running it, I ran into the issue that the parses crashed on a dark matter mod (I forget the exact name, but I think it is also academic). Because I was okay with having a little less information in exchange for this mostly working, I created this check.

Without this change the parser will crash on edge cases where it doesn't have the tech it expects to have in it's dictionary. It's not ideal, but skipping over it is better than outputting nothing at all.